### PR TITLE
Fix utf-8 encoding and reference replace problem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "ext-mbstring": "*",
         "php": ">=7.1",
         "contao/core-bundle": "^4",
         "sioweb/maintenance-fix": "*",

--- a/src/EventListener/Frontend.php
+++ b/src/EventListener/Frontend.php
@@ -178,14 +178,14 @@ class Frontend
 
         libxml_use_internal_errors(true);
         $dom = new \DOMDocument();
-        $dom->loadHTML($strContent, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $dom->loadHTML(mb_convert_encoding($strContent, 'HTML-ENTITIES', 'UTF-8'), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
         $xpath = new \DOMXPath($dom);
 
         foreach($ignoredTags as $tag) {
             foreach($xpath->query('//' . $tag) as $tagObj) {
                 $indexer = 'GLOSSAR::REPLACE::' . strtoupper($tag) . '::' . count($this->replaceIndex);
                 $CommentNode = $dom->createComment($indexer);
-                $this->replaceIndex[$indexer] = $tagObj;
+                $this->replaceIndex[$indexer] = $tagObj->cloneNode(true);
                 $tagObj->parentNode->replaceChild($CommentNode, $tagObj);
             }
         }

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -104,7 +104,7 @@ services:
             - "@database_connection"
             - "@request_stack"
         tags:
-            - { name: contao.hook, hook: cacheGlossarTerms, method: cacheGlossarTerms }
+            - { name: contao.hook, hook: cacheGlossarTerms, method: updateCache }
     sioweb.glossar.listener.news.glossarContent:
         class: Sioweb\Glossar\EventListener\CoreBundles\News
         public: true
@@ -142,7 +142,7 @@ services:
             - "@database_connection"
             - "@request_stack"
         tags:
-            - { name: contao.hook, hook: cacheGlossarTerms, method: cacheGlossarTerms }
+            - { name: contao.hook, hook: cacheGlossarTerms, method: updateCache }
     sioweb.glossar.listener.faq.glossarContent:
         class: Sioweb\Glossar\EventListener\CoreBundles\FAQ
         public: true
@@ -180,7 +180,7 @@ services:
             - "@database_connection"
             - "@request_stack"
         tags:
-            - { name: contao.hook, hook: cacheGlossarTerms, method: cacheGlossarTerms }
+            - { name: contao.hook, hook: cacheGlossarTerms, method: updateCache }
     sioweb.glossar.listener.event.glossarContent:
         class: Sioweb\Glossar\EventListener\CoreBundles\Events
         public: true


### PR DESCRIPTION
DOMDocument lädt das HTML nicht in UTF-8. Deshalb werden Umlaute nicht richtig angezeigt.
Um mit Umlauten im HTML umgehen zu können, müssen diese vorher umgewandelt werden.
Dies erreicht man mit `mb_convert_encoding($strContent, 'HTML-ENTITIES', 'UTF-8')`.

Des weiteren hatten wir das Problem, dass der Algorithmus zum Ersetzen der `ignoreInTags`-Tags nur die Referenz zum aktuellen DOM-Element in das Array speichert.
Wenn nun innerhalb eines der Elemente nochmal Tags auftreten, die mit Glossar-Kommentaren ersetzt werden sollen, wird der Eintrag im Array nachträglich geändert, weshalb die neuen HTML-Kommentare an dieser Stelle in die Seite geladen werden.
Durch das Erstellen eines neuen DOM-Elements mit `cloneNode(true)`, wird dies umgangen.