### PR TITLE
Fix soft dependencies

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -31,28 +31,19 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 class Plugin implements BundlePluginInterface, RoutingPluginInterface, ExtensionPluginInterface
 {
-    private $arrLoadAfter = [
-        ContaoCoreBundle::class,
-        ContaoCalendarBundle::class,
-        ContaoFaqBundle::class,
-        ContaoNewsBundle::class
-    ];
-
     /**
      * {@inheritdoc}
      */
     public function getBundles(ParserInterface $parser)
     {
-        $loadAfter = [];
-        foreach ($this->arrLoadAfter as $className) {
-            if (class_exists($className)) {
-                $loadAfter[] = $className;
-            }
-        }
-
         return [
             BundleConfig::create(SiowebGlossarBundle::class)
-                ->setLoadAfter($loadAfter)
+                ->setLoadAfter([
+                    ContaoCoreBundle::class,
+                    ContaoCalendarBundle::class,
+                    ContaoFaqBundle::class,
+                    ContaoNewsBundle::class
+                ])
                 ->setReplace(['SWGlossar']),
         ];
     }

--- a/src/EventListener/CoreBundles/Events.php
+++ b/src/EventListener/CoreBundles/Events.php
@@ -10,6 +10,7 @@ namespace Sioweb\Glossar\EventListener\CoreBundles;
 
 use Contao;
 use Contao\ArticleModel;
+use Contao\CalendarBundle\ContaoCalendarBundle;
 use Contao\CalendarEventsModel;
 use Contao\CalendarModel;
 use Contao\Config;
@@ -57,6 +58,10 @@ class Events
 
     public function clearGlossar($time)
     {
+        if (!class_exists(ContaoCalendarBundle::class)) {
+            return;
+        }
+
         $this->connection->prepare("UPDATE tl_calendar_events SET
             glossar = NULL, fallback_glossar = NULL, glossar_time = :glossar_time WHERE glossar_time != :glossar_time
         ")->execute([':glossar_time' => $time]);
@@ -64,6 +69,10 @@ class Events
 
     public function glossarContent($item, $strContent, $template)
     {
+        if (!class_exists(ContaoCalendarBundle::class)) {
+            return null;
+        }
+
         if (empty($item)) {
             return [];
         }
@@ -74,6 +83,10 @@ class Events
 
     public function updateCache($item, $arrTerms, $strContent)
     {
+        if (!class_exists(ContaoCalendarBundle::class)) {
+            return null;
+        }
+
         preg_match_all('#' . implode('|', $arrTerms['both']) . '#is', $strContent, $matches);
         $matches = array_unique($matches[0]);
 
@@ -88,6 +101,10 @@ class Events
 
     public function generateUrl($arrPages)
     {
+        if (!class_exists(ContaoCalendarBundle::class)) {
+            return [];
+        }
+
         $arrPages = [];
 
         $Event = CalendarEventsModel::findAll();

--- a/src/EventListener/CoreBundles/FAQ.php
+++ b/src/EventListener/CoreBundles/FAQ.php
@@ -11,6 +11,7 @@ namespace Sioweb\Glossar\EventListener\CoreBundles;
 use Contao\ArticleModel;
 use Contao\ContentModel;
 use Contao\Environment;
+use Contao\FaqBundle\ContaoFaqBundle;
 use Contao\FaqModel;
 use Contao\Input;
 use Contao\System;
@@ -58,6 +59,10 @@ class FAQ //extends ModuleFaqList
 
     public function clearGlossar($time)
     {
+        if (!class_exists(ContaoFaqBundle::class)) {
+            return;
+        }
+
         $this->connection->prepare("UPDATE tl_faq SET
             glossar = NULL, fallback_glossar = NULL, glossar_time = :glossar_time WHERE glossar_time != :glossar_time
         ")->execute([':glossar_time' => $time]);
@@ -65,6 +70,10 @@ class FAQ //extends ModuleFaqList
 
     public function glossarContent($item, $strContent, $template)
     {
+        if (!class_exists(ContaoFaqBundle::class)) {
+            return null;
+        }
+
         if (empty($item)) {
             return [];
         }
@@ -75,6 +84,10 @@ class FAQ //extends ModuleFaqList
 
     public function updateCache($item, $arrTerms, $strContent)
     {
+        if (!class_exists(ContaoFaqBundle::class)) {
+            return;
+        }
+
         preg_match_all('#' . implode('|', $arrTerms['both']) . '#is', $strContent, $matches);
         $matches = array_unique($matches[0]);
 
@@ -89,6 +102,10 @@ class FAQ //extends ModuleFaqList
 
     public function generateUrl($arrPages)
     {
+        if (!class_exists(ContaoFaqBundle::class)) {
+            return [];
+        }
+
         $arrPages = [];
 
         $Faq = FaqModel::findAll();

--- a/src/EventListener/CoreBundles/News.php
+++ b/src/EventListener/CoreBundles/News.php
@@ -15,6 +15,7 @@ use Contao\Input;
 use Contao\News as BaseNews;
 use Contao\ModuleModel;
 use Contao\ModuleNews;
+use Contao\NewsBundle\ContaoNewsBundle;
 use Contao\NewsModel;
 use Contao\System;
 use Contao\PageModel;
@@ -54,6 +55,10 @@ class News //extends BaseNews
 
     public function clearGlossar($time)
     {
+        if (!class_exists(ContaoFaqBundle::class)) {
+            return;
+        }
+
         $this->connection->prepare("UPDATE tl_news SET
             glossar = NULL, fallback_glossar = NULL, glossar_time = :glossar_time WHERE glossar_time != :glossar_time
         ")->execute([':glossar_time' => $time]);
@@ -61,6 +66,10 @@ class News //extends BaseNews
 
     public function glossarContent($item, $strContent, $template)
     {
+        if (!class_exists(ContaoFaqBundle::class)) {
+            return null;
+        }
+
         if (empty($item)) {
             return [];
         }
@@ -71,6 +80,10 @@ class News //extends BaseNews
 
     public function updateCache($item, $arrTerms, $strContent)
     {
+        if (!class_exists(ContaoFaqBundle::class)) {
+            return;
+        }
+
         $matches = [];
         foreach ($arrTerms['both'] as $term) {
             if (preg_match('#(' . $term . ')#is', $strContent, $match)) {
@@ -91,6 +104,10 @@ class News //extends BaseNews
 
     public function generateUrl($arrPages)
     {
+        if (!class_exists(ContaoFaqBundle::class)) {
+            return [];
+        }
+
         $arrPages = [];
 
         $News = NewsModel::findAll();

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -12,7 +12,11 @@
  * @copyright Sascha Weidner, Sioweb
  */
 
-if (VERSION <= 4.5) {
+use Contao\CalendarBundle\ContaoCalendarBundle;
+use Contao\FaqBundle\ContaoFaqBundle;
+use Contao\NewsBundle\ContaoNewsBundle;
+
+if (version_compare(VERSION, '4.5', '<=')) {
     $GLOBALS['TL_HOOKS']['initializeSystem'][]          = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\Setup', 'initializeSystem'];
     $GLOBALS['TL_HOOKS']['initializeSystem'][]          = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\Setup', 'initializeBackend'];
     $GLOBALS['TL_HOOKS']['initializeSystem'][]          = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\Setup', 'initializeFrontend'];
@@ -24,15 +28,21 @@ if (VERSION <= 4.5) {
     $GLOBALS['TL_HOOKS']['getSearchablePages'][]        = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\Backend', 'getSearchablePages'];
     $GLOBALS['TL_HOOKS']['outputFrontendTemplate'][]    = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\Frontend', 'searchGlossarTerms'];
 
-    $GLOBALS['TL_HOOKS']['clearGlossar'][]              = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\News', 'clearGlossar'];
-    $GLOBALS['TL_HOOKS']['cacheGlossarTerms'][]         = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\News', 'cacheGlossarTerms'];
-    $GLOBALS['TL_HOOKS']['glossarContent'][]            = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\News', 'glossarContent'];
+    if (class_exists(ContaoNewsBundle::class)) {
+        $GLOBALS['TL_HOOKS']['clearGlossar'][]              = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\News', 'clearGlossar'];
+        $GLOBALS['TL_HOOKS']['cacheGlossarTerms'][]         = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\News', 'cacheGlossarTerms'];
+        $GLOBALS['TL_HOOKS']['glossarContent'][]            = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\News', 'glossarContent'];
+    }
 
-    $GLOBALS['TL_HOOKS']['clearGlossar'][]              = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\Events', 'clearGlossar'];
-    $GLOBALS['TL_HOOKS']['cacheGlossarTerms'][]         = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\Events', 'cacheGlossarTerms'];
-    $GLOBALS['TL_HOOKS']['glossarContent'][]            = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\Events', 'glossarContent'];
+    if (class_exists(ContaoCalendarBundle::class)) {
+        $GLOBALS['TL_HOOKS']['clearGlossar'][]              = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\Events', 'clearGlossar'];
+        $GLOBALS['TL_HOOKS']['cacheGlossarTerms'][]         = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\Events', 'cacheGlossarTerms'];
+        $GLOBALS['TL_HOOKS']['glossarContent'][]            = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\Events', 'glossarContent'];
+    }
 
-    $GLOBALS['TL_HOOKS']['clearGlossar'][]              = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\FAQ', 'clearGlossar'];
-    $GLOBALS['TL_HOOKS']['cacheGlossarTerms'][]         = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\FAQ', 'cacheGlossarTerms'];
-    $GLOBALS['TL_HOOKS']['glossarContent'][]            = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\FAQ', 'glossarContent'];
+    if (class_exists(ContaoFaqBundle::class)) {
+        $GLOBALS['TL_HOOKS']['clearGlossar'][]              = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\FAQ', 'clearGlossar'];
+        $GLOBALS['TL_HOOKS']['cacheGlossarTerms'][]         = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\FAQ', 'cacheGlossarTerms'];
+        $GLOBALS['TL_HOOKS']['glossarContent'][]            = ['Sioweb\Glossar\Polyfill\Contao44\EventListener\CoreBundles\FAQ', 'glossarContent'];
+    }
 }

--- a/src/Resources/contao/dca/tl_calendar.php
+++ b/src/Resources/contao/dca/tl_calendar.php
@@ -12,17 +12,17 @@
  * @copyright Sascha Weidner, Sioweb
  */
 
-/**
- * Extend default palette
- */
-if (!empty($GLOBALS['TL_DCA']['tl_calendar']['palettes']['default'])) {
+use Contao\CalendarBundle\ContaoCalendarBundle;
+
+if (class_exists(ContaoCalendarBundle::class)) {
+	/**
+	 * Extend default palette
+	 */
 	Contao\CoreBundle\DataContainer\PaletteManipulator::create()
 		->addLegend('glossar_legend', 'comments_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_AFTER)
 		->addField(['glossar_disallow'], 'glossar_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
 		->applyToPalette('default', 'tl_calendar');
-}
 
-if (!empty($GLOBALS['TL_DCA']['tl_calendar']['fields'])) {
 	$GLOBALS['TL_DCA']['tl_calendar']['fields']['glossar_disallow'] = [
 		'label'				=> &$GLOBALS['TL_LANG']['tl_calendar']['glossar_disallow'],
 		'exclude'			=> true,

--- a/src/Resources/contao/dca/tl_calendar.php
+++ b/src/Resources/contao/dca/tl_calendar.php
@@ -15,15 +15,19 @@
 /**
  * Extend default palette
  */
-Contao\CoreBundle\DataContainer\PaletteManipulator::create()
-	->addLegend('glossar_legend', 'comments_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_AFTER)
-	->addField(['glossar_disallow'], 'glossar_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
-	->applyToPalette('default', 'tl_calendar');
+if (!empty($GLOBALS['TL_DCA']['tl_calendar']['palettes']['default'])) {
+	Contao\CoreBundle\DataContainer\PaletteManipulator::create()
+		->addLegend('glossar_legend', 'comments_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_AFTER)
+		->addField(['glossar_disallow'], 'glossar_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
+		->applyToPalette('default', 'tl_calendar');
+}
 
-$GLOBALS['TL_DCA']['tl_calendar']['fields']['glossar_disallow'] = [
-	'label'				=> &$GLOBALS['TL_LANG']['tl_calendar']['glossar_disallow'],
-	'exclude'			=> true,
-	'filter'			=> true,
-	'inputType'			=> 'checkbox',
-	'sql'				=> "char(1) NOT NULL default ''",
-];
+if (!empty($GLOBALS['TL_DCA']['tl_calendar']['fields'])) {
+	$GLOBALS['TL_DCA']['tl_calendar']['fields']['glossar_disallow'] = [
+		'label'				=> &$GLOBALS['TL_LANG']['tl_calendar']['glossar_disallow'],
+		'exclude'			=> true,
+		'filter'			=> true,
+		'inputType'			=> 'checkbox',
+		'sql'				=> "char(1) NOT NULL default ''",
+	];
+}

--- a/src/Resources/contao/dca/tl_calendar_events.php
+++ b/src/Resources/contao/dca/tl_calendar_events.php
@@ -12,7 +12,9 @@
  * @copyright Sascha Weidner, Sioweb
  */
 
-if (!empty($GLOBALS['TL_DCA']['tl_calendar_events']['fields'])) {
+use Contao\CalendarBundle\ContaoCalendarBundle;
+
+if (class_exists(ContaoCalendarBundle::class)) {
 	$GLOBALS['TL_DCA']['tl_calendar_events']['fields']['glossar'] = [
 		'sql' => "text NULL",
 	];

--- a/src/Resources/contao/dca/tl_calendar_events.php
+++ b/src/Resources/contao/dca/tl_calendar_events.php
@@ -12,14 +12,16 @@
  * @copyright Sascha Weidner, Sioweb
  */
 
-$GLOBALS['TL_DCA']['tl_calendar_events']['fields']['glossar'] = [
-	'sql' => "text NULL",
-];
+if (!empty($GLOBALS['TL_DCA']['tl_calendar_events']['fields'])) {
+	$GLOBALS['TL_DCA']['tl_calendar_events']['fields']['glossar'] = [
+		'sql' => "text NULL",
+	];
 
-$GLOBALS['TL_DCA']['tl_calendar_events']['fields']['fallback_glossar'] = [
-	'sql' => "text NULL",
-];
+	$GLOBALS['TL_DCA']['tl_calendar_events']['fields']['fallback_glossar'] = [
+		'sql' => "text NULL",
+	];
 
-$GLOBALS['TL_DCA']['tl_calendar_events']['fields']['glossar_time'] = [
-	'sql' => "int(10) unsigned NOT NULL default '0'",
-];
+	$GLOBALS['TL_DCA']['tl_calendar_events']['fields']['glossar_time'] = [
+		'sql' => "int(10) unsigned NOT NULL default '0'",
+	];
+}

--- a/src/Resources/contao/dca/tl_faq.php
+++ b/src/Resources/contao/dca/tl_faq.php
@@ -12,14 +12,16 @@
  * @copyright Sascha Weidner, Sioweb
  */
 
-$GLOBALS['TL_DCA']['tl_faq']['fields']['glossar'] = [
-    'sql' => "text NULL",
-];
+if (!empty($GLOBALS['TL_DCA']['tl_faq']['fields'])) {
+    $GLOBALS['TL_DCA']['tl_faq']['fields']['glossar'] = [
+        'sql' => "text NULL",
+    ];
 
-$GLOBALS['TL_DCA']['tl_faq']['fields']['fallback_glossar'] = [
-    'sql' => "text NULL",
-];
+    $GLOBALS['TL_DCA']['tl_faq']['fields']['fallback_glossar'] = [
+        'sql' => "text NULL",
+    ];
 
-$GLOBALS['TL_DCA']['tl_faq']['fields']['glossar_time'] = [
-    'sql' => "int(10) unsigned NOT NULL default '0'",
-];
+    $GLOBALS['TL_DCA']['tl_faq']['fields']['glossar_time'] = [
+        'sql' => "int(10) unsigned NOT NULL default '0'",
+    ];
+}

--- a/src/Resources/contao/dca/tl_faq.php
+++ b/src/Resources/contao/dca/tl_faq.php
@@ -12,7 +12,9 @@
  * @copyright Sascha Weidner, Sioweb
  */
 
-if (!empty($GLOBALS['TL_DCA']['tl_faq']['fields'])) {
+use Contao\FaqBundle\ContaoFaqBundle;
+
+if (class_exists(ContaoFaqBundle::class)) {
 	$GLOBALS['TL_DCA']['tl_faq']['fields']['glossar'] = [
 		'sql' => "text NULL",
 	];

--- a/src/Resources/contao/dca/tl_faq.php
+++ b/src/Resources/contao/dca/tl_faq.php
@@ -13,15 +13,15 @@
  */
 
 if (!empty($GLOBALS['TL_DCA']['tl_faq']['fields'])) {
-    $GLOBALS['TL_DCA']['tl_faq']['fields']['glossar'] = [
-        'sql' => "text NULL",
-    ];
+	$GLOBALS['TL_DCA']['tl_faq']['fields']['glossar'] = [
+		'sql' => "text NULL",
+	];
 
-    $GLOBALS['TL_DCA']['tl_faq']['fields']['fallback_glossar'] = [
-        'sql' => "text NULL",
-    ];
+	$GLOBALS['TL_DCA']['tl_faq']['fields']['fallback_glossar'] = [
+		'sql' => "text NULL",
+	];
 
-    $GLOBALS['TL_DCA']['tl_faq']['fields']['glossar_time'] = [
-        'sql' => "int(10) unsigned NOT NULL default '0'",
-    ];
+	$GLOBALS['TL_DCA']['tl_faq']['fields']['glossar_time'] = [
+		'sql' => "int(10) unsigned NOT NULL default '0'",
+	];
 }

--- a/src/Resources/contao/dca/tl_faq_category.php
+++ b/src/Resources/contao/dca/tl_faq_category.php
@@ -12,7 +12,6 @@
  * @copyright Sascha Weidner, Sioweb
  */
 
-
 /**
  * Extend default palette
  */

--- a/src/Resources/contao/dca/tl_faq_category.php
+++ b/src/Resources/contao/dca/tl_faq_category.php
@@ -16,15 +16,19 @@
 /**
  * Extend default palette
  */
-Contao\CoreBundle\DataContainer\PaletteManipulator::create()
-	->addLegend('glossar_legend', 'comments_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_AFTER)
-	->addField(['glossar_disallow'], 'glossar_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
-	->applyToPalette('default', 'tl_faq_category');
+if (!empty($GLOBALS['TL_DCA']['tl_faq_category']['palettes']['default'])) {
+	Contao\CoreBundle\DataContainer\PaletteManipulator::create()
+		->addLegend('glossar_legend', 'comments_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_AFTER)
+		->addField(['glossar_disallow'], 'glossar_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
+		->applyToPalette('default', 'tl_faq_category');
+}
 
-$GLOBALS['TL_DCA']['tl_faq_category']['fields']['glossar_disallow'] = [
-	'label'				=> &$GLOBALS['TL_LANG']['tl_faq_category']['glossar_disallow'],
-	'exclude'			=> true,
-	'filter'			=> true,
-	'inputType'			=> 'checkbox',
-	'sql'				=> "char(1) NOT NULL default ''",
-];
+if (!empty($GLOBALS['TL_DCA']['tl_faq_category']['fields'])) {
+	$GLOBALS['TL_DCA']['tl_faq_category']['fields']['glossar_disallow'] = [
+		'label'				=> &$GLOBALS['TL_LANG']['tl_faq_category']['glossar_disallow'],
+		'exclude'			=> true,
+		'filter'			=> true,
+		'inputType'			=> 'checkbox',
+		'sql'				=> "char(1) NOT NULL default ''",
+	];
+}

--- a/src/Resources/contao/dca/tl_faq_category.php
+++ b/src/Resources/contao/dca/tl_faq_category.php
@@ -12,17 +12,17 @@
  * @copyright Sascha Weidner, Sioweb
  */
 
-/**
- * Extend default palette
- */
-if (!empty($GLOBALS['TL_DCA']['tl_faq_category']['palettes']['default'])) {
+use Contao\FaqBundle\ContaoFaqBundle;
+
+if (class_exists(ContaoFaqBundle::class)) {
+	/**
+	 * Extend default palette
+	 */
 	Contao\CoreBundle\DataContainer\PaletteManipulator::create()
 		->addLegend('glossar_legend', 'comments_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_AFTER)
 		->addField(['glossar_disallow'], 'glossar_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
 		->applyToPalette('default', 'tl_faq_category');
-}
 
-if (!empty($GLOBALS['TL_DCA']['tl_faq_category']['fields'])) {
 	$GLOBALS['TL_DCA']['tl_faq_category']['fields']['glossar_disallow'] = [
 		'label'				=> &$GLOBALS['TL_LANG']['tl_faq_category']['glossar_disallow'],
 		'exclude'			=> true,

--- a/src/Resources/contao/dca/tl_news.php
+++ b/src/Resources/contao/dca/tl_news.php
@@ -12,14 +12,16 @@
  * @copyright Sascha Weidner, Sioweb
  */
 
-$GLOBALS['TL_DCA']['tl_news']['fields']['glossar'] = [
-	'sql' => "text NULL",
-];
+if (!empty($GLOBALS['TL_DCA']['tl_news']['fields'])) {
+	$GLOBALS['TL_DCA']['tl_news']['fields']['glossar'] = [
+		'sql' => "text NULL",
+	];
 
-$GLOBALS['TL_DCA']['tl_news']['fields']['fallback_glossar'] = [
-	'sql' => "text NULL",
-];
+	$GLOBALS['TL_DCA']['tl_news']['fields']['fallback_glossar'] = [
+		'sql' => "text NULL",
+	];
 
-$GLOBALS['TL_DCA']['tl_news']['fields']['glossar_time'] = [
-	'sql' => "int(10) unsigned NOT NULL default '0'",
-];
+	$GLOBALS['TL_DCA']['tl_news']['fields']['glossar_time'] = [
+		'sql' => "int(10) unsigned NOT NULL default '0'",
+	];
+}

--- a/src/Resources/contao/dca/tl_news.php
+++ b/src/Resources/contao/dca/tl_news.php
@@ -12,7 +12,9 @@
  * @copyright Sascha Weidner, Sioweb
  */
 
-if (!empty($GLOBALS['TL_DCA']['tl_news']['fields'])) {
+use Contao\NewsBundle\ContaoNewsBundle;
+
+if (class_exists(ContaoNewsBundle::class)) {
 	$GLOBALS['TL_DCA']['tl_news']['fields']['glossar'] = [
 		'sql' => "text NULL",
 	];

--- a/src/Resources/contao/dca/tl_news_archive.php
+++ b/src/Resources/contao/dca/tl_news_archive.php
@@ -15,15 +15,19 @@
 /**
  * Extend default palette
  */
-Contao\CoreBundle\DataContainer\PaletteManipulator::create()
-	->addLegend('glossar_legend', 'comments_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_AFTER)
-	->addField(['glossar_disallow'], 'glossar_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
-	->applyToPalette('default', 'tl_news_archive');
+if (!empty($GLOBALS['TL_DCA']['tl_news_archive']['palettes']['default'])) {
+	Contao\CoreBundle\DataContainer\PaletteManipulator::create()
+		->addLegend('glossar_legend', 'comments_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_AFTER)
+		->addField(['glossar_disallow'], 'glossar_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
+		->applyToPalette('default', 'tl_news_archive');
+}
 
-$GLOBALS['TL_DCA']['tl_news_archive']['fields']['glossar_disallow'] = [
-	'label'				=> &$GLOBALS['TL_LANG']['tl_news_archive']['glossar_disallow'],
-	'exclude'			=> true,
-	'filter'			=> true,
-	'inputType'			=> 'checkbox',
-	'sql'				=> "char(1) NOT NULL default ''",
-];
+if (!empty($GLOBALS['TL_DCA']['tl_news_archive']['fields'])) {
+	$GLOBALS['TL_DCA']['tl_news_archive']['fields']['glossar_disallow'] = [
+		'label'				=> &$GLOBALS['TL_LANG']['tl_news_archive']['glossar_disallow'],
+		'exclude'			=> true,
+		'filter'			=> true,
+		'inputType'			=> 'checkbox',
+		'sql'				=> "char(1) NOT NULL default ''",
+	];
+}

--- a/src/Resources/contao/dca/tl_news_archive.php
+++ b/src/Resources/contao/dca/tl_news_archive.php
@@ -12,17 +12,17 @@
  * @copyright Sascha Weidner, Sioweb
  */
 
-/**
- * Extend default palette
- */
-if (!empty($GLOBALS['TL_DCA']['tl_news_archive']['palettes']['default'])) {
+use Contao\NewsBundle\ContaoNewsBundle;
+
+if (class_exists(ContaoNewsBundle::class)) {
+	/**
+	 * Extend default palette
+	 */
 	Contao\CoreBundle\DataContainer\PaletteManipulator::create()
 		->addLegend('glossar_legend', 'comments_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_AFTER)
 		->addField(['glossar_disallow'], 'glossar_legend', Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
 		->applyToPalette('default', 'tl_news_archive');
-}
 
-if (!empty($GLOBALS['TL_DCA']['tl_news_archive']['fields'])) {
 	$GLOBALS['TL_DCA']['tl_news_archive']['fields']['glossar_disallow'] = [
 		'label'				=> &$GLOBALS['TL_LANG']['tl_news_archive']['glossar_disallow'],
 		'exclude'			=> true,


### PR DESCRIPTION
`sioweb/glossar` has soft dependencies on `contao/calendar-bundle`, `contao/faq-bundle` and `contao/news-bundle`. However, if any of these bundles are not installed, the following error will occur:

```
 In PaletteManipulator.php line 113:

    [Contao\CoreBundle\DataContainer\PaletteNotFoundException]  
    Palette "default" not found in table "tl_calendar"


  Exception trace:
    at vendor\contao\core-bundle\src\DataContainer\PaletteManipulator.php:113
   Contao\CoreBundle\DataContainer\PaletteManipulator->applyToPalette() at var\cache\prod\contao\dca\tl_calendar.php:22
   …
```

Since the DCA of `tl_calendar` and `tl_calendar_events` etc. will not be present if these bundles are not installed, you need to check for the existence of the DCA - or the bundle class - if you only have a soft dependency on these, since they might not be there.

This PR adds the necessary checks. This PR also fixes various other errors that occur, if any of the soft dependencies are not installed.